### PR TITLE
Refactor/profile-core: use ProfileService & ProfileModel instead of GithubApiService & GithubApiModel

### DIFF
--- a/lib/core/constants/github-api.constant.dart
+++ b/lib/core/constants/github-api.constant.dart
@@ -3,8 +3,4 @@ class GithubApiConstant {
   static const String USERNAME = 'nadzmiidzham';
   static const String API_URL = 'https://api.github.com';
   static const String USER_ENDPOINT = '/users';
-
-  static const String GITHUB_PROFILE_NAME = 'Muhammad Nadzmi';
-  static const String GITHUB_PROFILE_URL = 'https://github.com/nadzmiidzham';
-  static const String GITHUB_PROFILE_EMAIL = 'nadzmiidzham@gmail.com';
 }

--- a/lib/core/constants/profile.constant.dart
+++ b/lib/core/constants/profile.constant.dart
@@ -1,4 +1,9 @@
 class ProfileConstant {
+  static const String GITHUB_PROFILE_NAME = 'Muhammad Nadzmi';
+  static const String GITHUB_PROFILE_URL = 'https://github.com/nadzmiidzham';
+  static const String GITHUB_PROFILE_EMAIL = 'nadzmiidzham@gmail.com';
+  static const String PROFILE_IMAGE = 'assets/images/profile_image.jpg';
+
   static const List<Map<String, String>> SOCIAL_MEDIA_LINK_LIST = [
     {
       'iconPath': 'assets/images/github_logo.png',

--- a/lib/core/models/profile.model.dart
+++ b/lib/core/models/profile.model.dart
@@ -1,0 +1,36 @@
+import 'package:pomodoro_timer/core/models/social-media.model.dart';
+
+class ProfileModel {
+  String name, email, imagePath, profileUrl;
+  List<SocialMedia> socialMediaList;
+
+  ProfileModel({
+    this.name,
+    this.email,
+    this.imagePath,
+    this.profileUrl,
+    this.socialMediaList,
+  });
+
+  Map toJson() => {
+        'name': this.name,
+        'email': this.email,
+        'imagePath': this.imagePath,
+        'githubProfile': this.profileUrl,
+        'socialMediaList': this.socialMediaList,
+      };
+
+  factory ProfileModel.fromJson(Map<String, dynamic> json) {
+    return ProfileModel(
+      name: json['name'],
+      email: json['email'],
+      imagePath: json['imagePath'],
+      profileUrl: json['profileUrl'],
+      socialMediaList: json['socialMediaList'],
+    );
+  }
+
+  String toString() {
+    return '{name: ${this.name}, email: ${this.email}, imagePath: ${this.imagePath}, profileUrl: ${this.profileUrl}, socialMediaList: [${this.socialMediaList.join(",")}]}';
+  }
+}

--- a/lib/core/services/profile.service.dart
+++ b/lib/core/services/profile.service.dart
@@ -1,0 +1,26 @@
+import 'package:pomodoro_timer/core/models/github-profile.model.dart';
+import 'package:pomodoro_timer/core/models/profile.model.dart';
+import 'package:pomodoro_timer/core/models/social-media.model.dart';
+import 'package:pomodoro_timer/core/services/github-api.service.dart';
+import 'package:pomodoro_timer/core/services/social-media.service.dart';
+import 'package:pomodoro_timer/locator.dart';
+
+class ProfileService {
+  GithubApiService _githubApiService = locator<GithubApiService>();
+  SocialMediaService _socialMediaService = locator<SocialMediaService>();
+
+  Future<ProfileModel> getProfile() async {
+    GithubProfileModel githubProfile =
+        await _githubApiService.getGithubProfile();
+    List<SocialMedia> socialMediaList =
+        _socialMediaService.getSocialMediaList();
+
+    return ProfileModel.fromJson({
+      'name': githubProfile?.name,
+      'email': githubProfile?.email,
+      'imagePath': githubProfile?.profilePictureLink,
+      'profileUrl': githubProfile?.profileLink,
+      'socialMediaList': socialMediaList,
+    });
+  }
+}

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 import 'package:pomodoro_timer/core/services/cache.service.dart';
 import 'package:pomodoro_timer/core/services/github-api.service.dart';
+import 'package:pomodoro_timer/core/services/profile.service.dart';
 import 'package:pomodoro_timer/core/services/social-media.service.dart';
 import 'package:pomodoro_timer/core/services/timer.service..dart';
 import 'package:pomodoro_timer/ui/viewmodels/about.viewmodel.dart';
@@ -14,6 +15,7 @@ void setupLocator() {
   locator.registerLazySingleton(() => GithubApiService());
   locator.registerLazySingleton(() => CacheService());
   locator.registerLazySingleton(() => SocialMediaService());
+  locator.registerLazySingleton(() => ProfileService());
 
   // view models
   locator.registerLazySingleton(() => TimerViewModel());

--- a/lib/ui/shared/asset.constant.dart
+++ b/lib/ui/shared/asset.constant.dart
@@ -1,3 +1,0 @@
-class AssetConstant {
-  static const String PROFILE_IMAGE = 'assets/images/profile_image.jpg';
-}

--- a/lib/ui/viewmodels/about.viewmodel.dart
+++ b/lib/ui/viewmodels/about.viewmodel.dart
@@ -1,39 +1,35 @@
-import 'package:pomodoro_timer/core/constants/github-api.constant.dart';
-import 'package:pomodoro_timer/core/models/github-profile.model.dart';
-import 'package:pomodoro_timer/core/models/social-media.model.dart';
-import 'package:pomodoro_timer/core/services/github-api.service.dart';
-import 'package:pomodoro_timer/core/services/social-media.service.dart';
+import 'package:pomodoro_timer/core/constants/profile.constant.dart';
+import 'package:pomodoro_timer/core/models/profile.model.dart';
+import 'package:pomodoro_timer/core/services/profile.service.dart';
 import 'package:pomodoro_timer/locator.dart';
 import 'package:pomodoro_timer/ui/viewmodels/base.viewmodel.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class AboutViewModel extends BaseViewModel {
-  GithubApiService _githubApiService = locator<GithubApiService>();
-  SocialMediaService _socialMediaService = locator<SocialMediaService>();
-  GithubProfileModel _profile;
-  List<SocialMedia> _socialMediaList;
+  ProfileService _profileService = locator<ProfileService>();
+  ProfileModel _profile;
 
   // getter
-  String get profileLink {
-    return _profile.profileLink ?? GithubApiConstant.GITHUB_PROFILE_URL;
+  String get profileUrl {
+    return _profile.profileUrl ?? ProfileConstant.GITHUB_PROFILE_URL;
   }
 
   String get name {
-    return _profile.name ?? GithubApiConstant.GITHUB_PROFILE_NAME;
+    return _profile.name ?? ProfileConstant.GITHUB_PROFILE_NAME;
   }
 
-  String get profilePictureLink {
-    return _profile.profilePictureLink;
+  String get profilePicturePath {
+    return _profile.imagePath;
   }
 
   String get email {
-    return _profile.email ?? GithubApiConstant.GITHUB_PROFILE_EMAIL;
+    return _profile.email ?? ProfileConstant.GITHUB_PROFILE_EMAIL;
   }
 
   List<Map<String, dynamic>> get socialMediaList {
     List<Map<String, dynamic>> list = [];
 
-    _socialMediaList.forEach((element) {
+    _profile.socialMediaList.forEach((element) {
       list.add(
           {'iconPath': element.iconPath, 'profileLink': element.profileLink});
     });
@@ -44,9 +40,7 @@ class AboutViewModel extends BaseViewModel {
   // init methods
   initProfile() async {
     setState(ViewState.BUSY);
-    _profile =
-        await _githubApiService.getGithubProfile() ?? GithubProfileModel();
-    _socialMediaList = _socialMediaService.getSocialMediaList();
+    _profile = await _profileService.getProfile();
     setState(ViewState.IDLE);
   }
 

--- a/lib/ui/views/about.view.dart
+++ b/lib/ui/views/about.view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:pomodoro_timer/ui/shared/asset.constant.dart';
+import 'package:pomodoro_timer/core/constants/profile.constant.dart';
 import 'package:pomodoro_timer/ui/viewmodels/about.viewmodel.dart';
 import 'package:pomodoro_timer/ui/viewmodels/base.viewmodel.dart';
 import 'package:pomodoro_timer/ui/views/base.view.dart';
@@ -20,17 +20,17 @@ class AboutView extends StatelessWidget {
               ? CircularProgressIndicator()
               : Column(
                   children: [
-                    viewModel.profilePictureLink == null
-                        ? _profilePicture(AssetConstant.PROFILE_IMAGE, true)
-                        : _profilePicture(viewModel.profilePictureLink, false,
+                    viewModel.profilePicturePath == null
+                        ? _profilePicture(ProfileConstant.PROFILE_IMAGE, true)
+                        : _profilePicture(viewModel.profilePicturePath, false,
                             onTap: () {
-                            viewModel.openWebBrowser(viewModel.profileLink);
+                            viewModel.openWebBrowser(viewModel.profileUrl);
                           }),
                     _name(viewModel.name),
                     _email(viewModel.email, onTap: () {
                       viewModel.openEmailApp(viewModel.email);
                     }),
-                    _socialMedia(viewModel.socialMediaList,
+                    _socialMedia(viewModel.socialMediaList ?? [],
                         onTap: (url) => viewModel.openWebBrowser(url)),
                   ],
                 ),


### PR DESCRIPTION
- added ProfileService, ProfileModel & ProfileConstant
- use ProfileService to initialize profile data instead of GithubApiService
- move all profile related constant from GithubApiConstant to ProfileConstant
- renamed `profileLink` to `profileUrl`
- UI will not do value checking, instead viewmodel do the checking